### PR TITLE
Fix build on latest noVNC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.12.0
 LABEL maintainer=doug.warren@gmail.com
 
 ENV HOME=/root \
@@ -9,7 +9,8 @@ ENV HOME=/root \
 	REMOTE_HOST=localhost \
 	REMOTE_PORT=5900
 
-RUN apk --update --upgrade add git bash supervisor nodejs nodejs-npm \
+RUN apk --update --upgrade add git bash supervisor nodejs nodejs-npm python3 \
+    && ln -s /usr/bin/python3 /usr/bin/python \
 	&& git clone https://github.com/novnc/noVNC.git /root/noVNC \
 	&& git clone https://github.com/novnc/websockify /root/noVNC/utils/websockify \
 	&& rm -rf /root/noVNC/.git \


### PR DESCRIPTION
Updated alpine version. This causes node version to update. 
Latest version of alpine didn't have Python installed (that is required by websockify) so also installed Python.

Otherwise docker build fails with:
```
npm WARN ws@7.3.1 requires a peer of utf-8-validate@^5.0.2 but none was installed.
/root/noVNC/node_modules/fs-extra/lib/index.js:5
  ...require('./fs'),
  ^^^
SyntaxError: Unexpected token ...
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/root/noVNC/utils/use_require.js:6:13)
The command '/bin/sh -c apk --update --upgrade add git bash supervisor nodejs nodejs-npm 	&& git clone https://github.com/novnc/noVNC.git /root/noVNC 	&& cd /root/noVNC 	&& npm install 	&& ./utils/use_require.js --as commonjs --with-app 	&& cp /root/noVNC/node_modules/requirejs/require.js /root/noVNC/build 	&& sed -i -- "s/ps -p/ps -o pid | grep/g" /root/noVNC/utils/launch.sh 	&& apk del git nodejs-npm nodejs' returned a non-zero code: 1```